### PR TITLE
Add an example to get the hostname from metadata

### DIFF
--- a/docs/reference/migrating-to-clcs/_index.md
+++ b/docs/reference/migrating-to-clcs/_index.md
@@ -251,7 +251,7 @@ storage:
         inline: coreos1
 ```
 
-If your cloud provider uses a meta-data service, you can get the hostname from it. For example with openstack:
+On a cloud having an `http` metadata service, the hostname can be retrieved automatically. For example with openstack:
 
 ```yaml
 storage:

--- a/docs/reference/migrating-to-clcs/_index.md
+++ b/docs/reference/migrating-to-clcs/_index.md
@@ -251,6 +251,17 @@ storage:
         inline: coreos1
 ```
 
+If your cloud provider uses a meta-data service, you can get the hostname from it. For example with openstack:
+
+```yaml
+storage:
+  files:
+    - path:       "/etc/hostname"
+      contents:
+        remote:
+          url: http://169.254.169.254/latest/meta-data/hostname
+```
+
 ### users
 
 The `users` section in a cloud-config can be used to add users and specify many properties about them, from groups the user should be in to what the user's shell should be.


### PR DESCRIPTION
It was not obvious to me how I could set the hostname of an openstack instance. The `coreos-metadata` service doesn't seem to do it by itself, as I would have expected.

So I searched how to do it with ignition and it took me too much time. I thought that a mention in the documentation could help.